### PR TITLE
Updated Dockerfile for multiarch build for amd64, s390x and ppc64le

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,21 @@
-FROM registry.access.redhat.com/ubi8:8.10-1020
+FROM registry.access.redhat.com/ubi9/ubi:latest
 
 COPY *.py app/
 COPY requirements.txt app/
 COPY bigrams.json app/
 
 WORKDIR app
+RUN dnf install -y \
+        gcc \
+        gcc-c++ \
+        make \
+        redhat-rpm-config && \
+    dnf clean all
 
 # install python
 RUN dnf install -y jq python3.12 python3.12-devel python3.12-pip unzip && \
     dnf clean all && \
-    pip3 install -r requirements.txt
+    python3.12 -m pip install -r requirements.txt
 
 EXPOSE 8000
 CMD ["uvicorn", "vllm_emulator:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
Updated Dockerfile for multiarch build for amd64, s390x and ppc64le.
[vllm_emulator_build_log.txt](https://github.com/user-attachments/files/22499099/vllm_emulator_build_log.txt)
